### PR TITLE
Create AddMessage function wrapper

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,0 @@
-image: Visual Studio 2017
-configuration:
-  - Release
-  - Debug
-build:
-  project: OP2Helper.sln

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,5 +2,10 @@ image: Visual Studio 2017
 configuration:
   - Release
   - Debug
+install:
+  # Depends on Outpost2DLL, but has no formal submodule dependency set
+  # Manually download Outpost2DLL to a compatible relative location
+  - cd %APPVEYOR_BUILD_FOLDER%\..
+  - git clone https://github.com/OutpostUniverse/Outpost2DLL
 build:
   project: OP2Helper.sln

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,6 @@
+image: Visual Studio 2017
+configuration:
+  - Release
+  - Debug
+build:
+  project: OP2Helper.sln

--- a/OP2Helper.cpp
+++ b/OP2Helper.cpp
@@ -130,7 +130,7 @@ void CenterViewOnPlayerCC() {
 }
 
 void AddMapMessage(const char* message, const Unit& sourceUnit, int soundIndex, int toPlayerNum) {
-	// message is passed into outpost 2 as a non const argument. The value of message is not modified by Outpost 2.
+	// Message is not modified by Outpost 2, but was not declared as const. Cast to avoid warnings/errors.
 	TethysGame::AddMessage(sourceUnit, const_cast<char*>(message), toPlayerNum, soundIndex);
 }
 
@@ -142,7 +142,7 @@ void AddMapMessage(const char* message, const LOCATION& location, int soundIndex
 
 void AddMapMessage(const char* message, int pixelX, int pixelY, int soundIndex, int toPlayerNum)
 {
-	// message is passed into outpost 2 as a non const argument. The value of message is not modified by Outpost 2.
+	// Message is not modified by Outpost 2, but was not declared as const. Cast to avoid warnings/errors.
 	TethysGame::AddMessage(pixelX, pixelY, const_cast<char*>(message), toPlayerNum, soundIndex);
 }
 

--- a/OP2Helper.cpp
+++ b/OP2Helper.cpp
@@ -136,14 +136,8 @@ void AddMapMessage(const char* message, const Unit& sourceUnit, int soundIndex, 
 
 void AddMapMessage(const char* message, const LOCATION& location, int soundIndex, int toPlayerNum)
 {
-	int pixelX = -1;
-	int pixelY = -1;
-	if (location != LOCATION(-1,-1)) {
-		pixelX = location.x * 32 + 16;
-		pixelY = location.y * 32 + 16;
-	}
-
-	AddMapMessage(message, pixelX, pixelY, soundIndex, toPlayerNum);
+	// Convert location from tiles to pixels
+	AddMapMessage(message, location.x * 32 + 16, location.y * 32 + 16, soundIndex, toPlayerNum);
 }
 
 void AddMapMessage(const char* message, int pixelX, int pixelY, int soundIndex, int toPlayerNum)

--- a/OP2Helper.cpp
+++ b/OP2Helper.cpp
@@ -124,7 +124,20 @@ void CenterViewOnPlayerCC() {
 	}
 }
 
-void AddMessage(const char* message, int soundIndex, int toPlayerNum, Unit sourceUnit) {
+void AddMessage(const char* message, Unit sourceUnit, int soundIndex, int toPlayerNum) {
 	// message is passed into outpost 2 as a non const argument. The value of message is not modified by Outpost 2.
 	TethysGame::AddMessage(sourceUnit, const_cast<char*>(message), toPlayerNum, soundIndex);
+}
+
+void AddMessage(const char* message, const LOCATION& location, int soundIndex, int toPlayerNum)
+{
+	int pixelX = -1;
+	int pixelY = -1;
+	if (location.x != NullLocation.x || location.y != NullLocation.y) {
+		pixelX = location.x * 32 + 16;
+		pixelY = location.y * 32 + 16;
+	}
+
+	// message is passed into outpost 2 as a non const argument. The value of message is not modified by Outpost 2.
+	TethysGame::AddMessage(pixelX, pixelY, const_cast<char*>(message), toPlayerNum, soundIndex);
 }

--- a/OP2Helper.cpp
+++ b/OP2Helper.cpp
@@ -110,6 +110,15 @@ LOCATION operator- (const LOCATION &loc1, const LOCATION &loc2)
 	return LOCATION(loc1.x - loc2.x, loc1.y - loc2.y);
 }
 
+bool operator== (const LOCATION& loc1, const LOCATION &loc2)
+{
+	return (loc1.x == loc2.x && loc1.y == loc2.y);
+}
+
+bool operator!= (const LOCATION& loc1, const LOCATION &loc2)
+{
+	return (loc1.x != loc2.x || loc1.y != loc2.y);
+}
 
 // Centers the local player's view on their CommandCenter, if they have one.
 void CenterViewOnPlayerCC() {
@@ -133,7 +142,7 @@ void AddMessage(const char* message, const LOCATION& location, int soundIndex, i
 {
 	int pixelX = -1;
 	int pixelY = -1;
-	if (location.x != NullLocation.x || location.y != NullLocation.y) {
+	if (location == NullLocation) {
 		pixelX = location.x * 32 + 16;
 		pixelY = location.y * 32 + 16;
 	}

--- a/OP2Helper.cpp
+++ b/OP2Helper.cpp
@@ -124,7 +124,7 @@ void CenterViewOnPlayerCC() {
 	}
 }
 
-void AddMessage(const char* message, Unit sourceUnit, int soundIndex, int toPlayerNum) {
+void AddMessage(const char* message, const Unit& sourceUnit, int soundIndex, int toPlayerNum) {
 	// message is passed into outpost 2 as a non const argument. The value of message is not modified by Outpost 2.
 	TethysGame::AddMessage(sourceUnit, const_cast<char*>(message), toPlayerNum, soundIndex);
 }

--- a/OP2Helper.cpp
+++ b/OP2Helper.cpp
@@ -100,24 +100,20 @@ void CreateNoCommandCenterFailureCondition(int playerNum)
 }
 
 
-LOCATION operator+ (const LOCATION &loc1, const LOCATION &loc2)
-{
+LOCATION operator+ (const LOCATION &loc1, const LOCATION &loc2) {
 	return LOCATION(loc1.x + loc2.x, loc1.y + loc2.y);
 }
 
-LOCATION operator- (const LOCATION &loc1, const LOCATION &loc2)
-{
+LOCATION operator- (const LOCATION &loc1, const LOCATION &loc2) {
 	return LOCATION(loc1.x - loc2.x, loc1.y - loc2.y);
 }
 
-bool operator== (const LOCATION& loc1, const LOCATION &loc2)
-{
+bool operator== (const LOCATION& loc1, const LOCATION &loc2) {
 	return (loc1.x == loc2.x && loc1.y == loc2.y);
 }
 
-bool operator!= (const LOCATION& loc1, const LOCATION &loc2)
-{
-	return (loc1.x != loc2.x || loc1.y != loc2.y);
+bool operator!= (const LOCATION& loc1, const LOCATION &loc2) {
+	return !(loc1 == loc2);
 }
 
 // Centers the local player's view on their CommandCenter, if they have one.

--- a/OP2Helper.cpp
+++ b/OP2Helper.cpp
@@ -129,20 +129,30 @@ void CenterViewOnPlayerCC() {
 	}
 }
 
-void AddMessage(const char* message, const Unit& sourceUnit, int soundIndex, int toPlayerNum) {
+void AddMapMessage(const char* message, const Unit& sourceUnit, int soundIndex, int toPlayerNum) {
 	// message is passed into outpost 2 as a non const argument. The value of message is not modified by Outpost 2.
 	TethysGame::AddMessage(sourceUnit, const_cast<char*>(message), toPlayerNum, soundIndex);
 }
 
-void AddMessage(const char* message, const LOCATION& location, int soundIndex, int toPlayerNum)
+void AddMapMessage(const char* message, const LOCATION& location, int soundIndex, int toPlayerNum)
 {
 	int pixelX = -1;
 	int pixelY = -1;
-	if (location == NullLocation) {
+	if (location != LOCATION(-1,-1)) {
 		pixelX = location.x * 32 + 16;
 		pixelY = location.y * 32 + 16;
 	}
 
+	AddMapMessage(message, pixelX, pixelY, soundIndex, toPlayerNum);
+}
+
+void AddMapMessage(const char* message, int pixelX, int pixelY, int soundIndex, int toPlayerNum)
+{
 	// message is passed into outpost 2 as a non const argument. The value of message is not modified by Outpost 2.
 	TethysGame::AddMessage(pixelX, pixelY, const_cast<char*>(message), toPlayerNum, soundIndex);
+}
+
+void AddGameMessage(const char* message, int soundIndex, int toPlayerNum)
+{
+	AddMapMessage(message, -1, -1, soundIndex, toPlayerNum);
 }

--- a/OP2Helper.cpp
+++ b/OP2Helper.cpp
@@ -123,3 +123,8 @@ void CenterViewOnPlayerCC() {
 		Player[localPlayer].CenterViewOn(commandCenterLoc.x, commandCenterLoc.y);
 	}
 }
+
+void AddMessage(const char* message, int soundIndex, int toPlayerNum, Unit sourceUnit) {
+	// message is passed into outpost 2 as a non const argument. The value of message is not modified by Outpost 2.
+	TethysGame::AddMessage(sourceUnit, const_cast<char*>(message), toPlayerNum, soundIndex);
+}

--- a/OP2Helper.h
+++ b/OP2Helper.h
@@ -89,3 +89,10 @@ void RandomizeList(int numItems, ListItemType list[])
 
 // Centers the local player's screen on their CC, if they have one.
 void CenterViewOnPlayerCC();
+
+// Use when passing a non-existing unit.
+const Unit NullUnit;
+
+// Set toPlayerNum = -1 to send to all players. 
+// Default sound effect is phone ringing (sending text message to other player)
+void AddMessage(const char* message, int soundIndex = SoundID::sndMessage2, int toPlayerNum = -1, Unit sourceUnit = NullUnit);

--- a/OP2Helper.h
+++ b/OP2Helper.h
@@ -42,7 +42,8 @@ extern const ResourceSet CES1ResourceSet;
  */
 LOCATION operator+ (const LOCATION &loc1, const LOCATION &loc2);
 LOCATION operator- (const LOCATION &loc1, const LOCATION &loc2);
-
+bool operator== (const LOCATION& loc1, const LOCATION &loc2);
+bool operator!= (const LOCATION& loc1, const LOCATION &loc2);
 
 // *************************************************
 // Note: The following are general purpose functions

--- a/OP2Helper.h
+++ b/OP2Helper.h
@@ -95,6 +95,6 @@ const LOCATION NullLocation(-1, -1);
 
 // To send message to all players, Set toPlayerNum to -1. 
 // Default sound effect is phone ringing (sending text message to other player)
-void AddMessage(const char* message, Unit sourceUnit, int soundIndex = SoundID::sndMessage2, int toPlayerNum = -1);
+void AddMessage(const char* message, const Unit& sourceUnit, int soundIndex = SoundID::sndMessage2, int toPlayerNum = PlayerNum::PlayerAll);
 // To add a message that is location agnostic, use NullLocation (-1, -1)
-void AddMessage(const char* message, const LOCATION& location = NullLocation, int soundIndex = SoundID::sndMessage2, int toPlayerNum = -1);
+void AddMessage(const char* message, const LOCATION& location = NullLocation, int soundIndex = SoundID::sndMessage2, int toPlayerNum = PlayerNum::PlayerAll);

--- a/OP2Helper.h
+++ b/OP2Helper.h
@@ -90,9 +90,11 @@ void RandomizeList(int numItems, ListItemType list[])
 // Centers the local player's screen on their CC, if they have one.
 void CenterViewOnPlayerCC();
 
-// Use when passing a non-existing unit.
-const Unit NullUnit;
+// Use when location does not actually exist.
+const LOCATION NullLocation(-1, -1);
 
-// Set toPlayerNum = -1 to send to all players. 
+// To send message to all players, Set toPlayerNum to -1. 
 // Default sound effect is phone ringing (sending text message to other player)
-void AddMessage(const char* message, int soundIndex = SoundID::sndMessage2, int toPlayerNum = -1, Unit sourceUnit = NullUnit);
+void AddMessage(const char* message, Unit sourceUnit, int soundIndex = SoundID::sndMessage2, int toPlayerNum = -1);
+// To add a message that is location agnostic, use NullLocation (-1, -1)
+void AddMessage(const char* message, const LOCATION& location = NullLocation, int soundIndex = SoundID::sndMessage2, int toPlayerNum = -1);

--- a/OP2Helper.h
+++ b/OP2Helper.h
@@ -91,11 +91,10 @@ void RandomizeList(int numItems, ListItemType list[])
 // Centers the local player's screen on their CC, if they have one.
 void CenterViewOnPlayerCC();
 
-// Use when location does not actually exist.
-const LOCATION NullLocation(-1, -1);
-
 // To send message to all players, Set toPlayerNum to -1. 
 // Default sound effect is phone ringing (sending text message to other player)
-void AddMessage(const char* message, const Unit& sourceUnit, int soundIndex = SoundID::sndMessage2, int toPlayerNum = PlayerNum::PlayerAll);
-// To add a message that is location agnostic, use NullLocation (-1, -1)
-void AddMessage(const char* message, const LOCATION& location = NullLocation, int soundIndex = SoundID::sndMessage2, int toPlayerNum = PlayerNum::PlayerAll);
+void AddMapMessage(const char* message, const Unit& sourceUnit, int soundIndex = SoundID::sndMessage2, int toPlayerNum = PlayerNum::PlayerAll);
+void AddMapMessage(const char* message, const LOCATION& location, int soundIndex = SoundID::sndMessage2, int toPlayerNum = PlayerNum::PlayerAll);
+void AddMapMessage(const char* message, int pixelX, int pixelY, int soundIndex = SoundID::sndMessage2, int toPlayerNum = PlayerNum::PlayerAll);
+// Game message not tied to a map location (always full volume)
+void AddGameMessage(const char* message, int soundIndex = SoundID::sndMessage2, int toPlayerNum = PlayerNum::PlayerAll);


### PR DESCRIPTION
First pass for pushing const_char cast detail to centralized point in OP2Helper. Leverages default function arguments to reduce calling code bulk.

Considered adding 

``` C++
void AddMessage(const char *message, int pixelX, int pixelY, int soundIndex = SoundID::sndMessage2, int toPlayerNum = -1);

void AddMessage(const char *message, LOCATION(), int pixelX, int pixelY, int soundIndex, int toPlayerNum) {
	// message is passed into outpost 2 as a non const argument. The value of message is not modified by Outpost 2.
	TethysGame::AddMessage(pixelX, pixelY, const_cast<char*>(message), toPlayerNum, soundIndex);
}
```

However, I think pixelX and pixelY would need to get passed by a point structure to allow both versions of AddMessage to work properly when using default parameters. I thought about using LOCATION, but it seems to specify tile location, which I didn't want to have the user confused about.

-Brett